### PR TITLE
(Test) Socket should report that bowserify is malicious / typosquat attack

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "eslint-plugin-standard": "^2.0.1",
     "eslint-plugin-react": "^6.9.0",
     "gh-pages": "^0.12.0",
-    "react-scripts": "0.8.5"
+    "react-scripts": "0.8.5",
+    "bowserify": "10.2.1"
   },
   "dependencies": {
     "chess.js": "^0.10.2",


### PR DESCRIPTION
Assert that Socket fails PR checks and reports that bowserify is a typosquat package, attempting to pose as browserify